### PR TITLE
feat: allow using nested source object

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "license": "MIT",
   "dependencies": {
     "caporal": "^1.1.0",
+    "flat": "^5.0.2",
     "load-json-file": "^5.1.0",
     "object-path": "^0.11.4",
     "shelljs": "^0.8.3",

--- a/src/tasks/generate-locale-function.js
+++ b/src/tasks/generate-locale-function.js
@@ -3,13 +3,14 @@ const loadJsonFile = require('load-json-file');
 const fs = require('fs');
 const objectPath = require("object-path");
 const shell = require('shelljs');
+const flatten = require('flat');
 
 async function generateLocaleFunction({input, output, functionName, nested, withTranslation, showTranslations, singleCurlyBraces, reactHook}) {
     if (!input) {
         console.error('\033[31m', 'generateJsFile: expected argument \'--input\'');
         process.exit(1);
     }
-    const localeKeysJSON = await loadJsonFile(input);
+    const localeKeysJSON = flatten(await loadJsonFile(input));
 
     const tsFunctionBuilder = new TSLocaleKeysFunctionBuilder({nested, withTranslation, localeKeysJSON, showTranslations, singleCurlyBraces, functionName, reactHook});
 


### PR DESCRIPTION
Allow using also nested format of messages file

f.e.

```json
{
  "common": {
    "create": "Create"
  }
}
```

by flattening each input object to match existing logic

so after flattening it start looking like

```json
{
  "common.create":  "Create"
}
```